### PR TITLE
Split backend into 2 microservices

### DIFF
--- a/finsearch_backend_embedding/abstract.py
+++ b/finsearch_backend_embedding/abstract.py
@@ -1,0 +1,94 @@
+# Relation and Abstract classes
+# Loads additional abstract information using doc_key for Abstract
+import utils
+
+# Load abstract sentences information
+FINKB_SENTENCES = utils.load_json("data/abstract_sentences.json")
+FINKB_EXTRAINFO = utils.load_csv("data/abstract_extra_info.csv", list_cols = ['authors'])
+
+class Relation:
+    def __init__(self, relation_dict, relation_score):
+        self.e1_str = relation_dict["E1"]
+        self.e1_start = relation_dict["E1_START"]
+        self.e1_end = relation_dict["E1_END"]
+        self.e2_str = relation_dict["E2"]
+        self.e2_start = relation_dict["E2_START"]
+        self.e2_end = relation_dict["E2_END"]
+        self.relation = relation_dict["REL"]
+        self.relation_score = relation_score
+
+    def get_relation_span(self):
+        relation_start = min(self.e1_start, self.e2_start)
+        relation_end = max(self.e1_end, self.e2_end)
+        return [relation_start, relation_end]
+    
+    def get_relation_score(self):
+        return self.relation_score
+
+    def to_dict(self):
+        relation_dict = {
+            'e1': self.e1_str, 
+            'e1_start': self.e1_start, 
+            'e1_end': self.e1_end, 
+            'e2': self.e2_str, 
+            'e2_start': self.e2_start, 
+            'e2_end': self.e2_end, 
+            'relation': self.relation, 
+            'relation_score': self.get_relation_score()
+        }
+        return relation_dict
+
+class Abstract:
+    def __init__(self, doc_key):
+        self.doc_key = doc_key 
+        self.relation_score = -1
+        self.relations = []
+        self.closest_relation = None
+
+        # Load extra information
+        self.sentences = FINKB_SENTENCES[str(self.doc_key)]
+        abstract_extra_df = FINKB_EXTRAINFO.loc[FINKB_EXTRAINFO.id == self.doc_key].iloc[0]
+        self.authors = abstract_extra_df.authors
+        self.abstract = abstract_extra_df.abstract
+        self.title = abstract_extra_df.title 
+        self.doi = abstract_extra_df.doi 
+        self.date = abstract_extra_df.date 
+        self.source = abstract_extra_df.journal
+    
+    def get_relation_score(self):
+        return self.relation_score
+
+    def get_doc_key(self):
+        return self.doc_key
+    
+    def add_relation(self, new_relation, new_relation_score):
+        # create new relation
+        new_relation_obj = Relation(new_relation, new_relation_score)
+
+        # update relation score
+        if self.relation_score < new_relation_score:
+            self.closest_relation = new_relation_obj
+            self.relation_score = new_relation_score
+
+        # add relation
+        self.relations.append(new_relation_obj)
+
+
+    def __lt__(self, other):
+        return self.get_relation_score() < other.get_relation_score()
+
+    def to_dict(self):
+        abstract_dict = {
+            "doc_key": self.get_doc_key(), 
+            "relation_score": self.get_relation_score(), 
+            "relations": [x.to_dict() for x in self.relations],
+            "closest_relation": self.closest_relation.to_dict(),
+            "authors": self.authors,
+            "sentences": self.sentences,
+            "title": self.title,
+            "doi": self.doi, 
+            "date": self.date, 
+            "source": self.source
+        }
+        return abstract_dict
+    

--- a/finsearch_backend_embedding/app.py
+++ b/finsearch_backend_embedding/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, request
+import query
+
+print("FINSEARCH BACKEND LOADED...")
+
+# instantiate the app
+app = Flask(__name__)
+app.config.from_object(__name__)
+
+# enable CORS
+
+@app.route("/")
+def main():
+    return "<h1>Finsearch Backend Embedding</h1>"
+
+@app.route("/search")
+def search():
+    entity1 = request.args.get('entity1')
+    entity2 = request.args.get('entity2')
+    direction = bool(request.args.get('direction'))
+    threshold = float(request.args.get('threshold'))
+    granular = bool(request.args.get('granular'))
+    model = request.args.get('model')
+    print(entity1, entity2, direction, threshold, granular, model)
+
+    print("search query called")
+    search_results = query.search_query(
+        e1=entity1, e2=entity2, granular=granular, dir=direction, threshold=threshold, model=model
+    )
+    print("search results returned")
+    print(search_results)
+    return {
+        0:search_results,
+        }
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/finsearch_backend_embedding/encoder.py
+++ b/finsearch_backend_embedding/encoder.py
@@ -1,0 +1,34 @@
+from sentence_transformers import SentenceTransformer, util
+import torch
+from finbert_embedding.embedding import FinbertEmbedding
+
+class Encoder: 
+    def __init__(self, model_name):
+        self.model_name = model_name
+        if "finbert" in self.model_name:
+            self.model = FinbertEmbedding()
+        else:
+            self.model = SentenceTransformer(self.model_name)
+        
+    def encode_entity(self, text):
+        if "finbert" in self.model_name:
+            return self.model.sentence_vector(text).tolist()
+        else:
+            return self.model.encode(text, convert_to_tensor=True).tolist()
+    
+    def entity_similarity(self, embedding1, embedding2):
+        embedding1 = torch.Tensor(embedding1)
+        embedding2 = torch.Tensor(embedding2)
+        rel_score = util.pytorch_cos_sim(embedding1, embedding2)
+        return float(rel_score[0][0])
+    
+    def query_similarity(self, query1, query2, gold1, gold2, dir=False):
+        sim11 = self.entity_similarity(query1, gold1)
+        sim12 = self.entity_similarity(query1, gold2)
+        sim21 = self.entity_similarity(query2, gold1)
+        sim22 = self.entity_similarity(query2, gold2)
+
+        if dir: # direction of entity matters
+            return (sim11 + sim22)/2
+        else:
+            return max((sim11 + sim22)/2, (sim12 + sim21)/2)

--- a/finsearch_backend_embedding/query.py
+++ b/finsearch_backend_embedding/query.py
@@ -1,0 +1,67 @@
+import utils
+import encoder
+import abstract
+
+# Load finbert model
+models = {
+    'finbert': encoder.Encoder('ProsusAI/finbert'),
+    'multiqa': encoder.Encoder('multi-qa-MiniLM-L6-cos-v1'),
+    'msmarco': encoder.Encoder('msmarco-MiniLM-L6-cos-v5'),
+    'roberta': encoder.Encoder('stsb-roberta-large')
+}
+
+# Load FinKB entities
+finkbs = {
+    'finbert': {
+        'granular': utils.load_jsonl('data/finkb/finbert/granular.jsonl'),
+        'coarse': utils.load_jsonl('data/finkb/finbert/coarse.jsonl')
+    },
+    'multiqa': {
+        'granular': utils.load_jsonl('data/finkb/multiqa/granular.jsonl'),
+        'coarse': utils.load_jsonl('data/finkb/multiqa/coarse.jsonl')
+    },
+    'msmarco': {
+        'granular': utils.load_jsonl('data/finkb/msmarco/granular.jsonl'),
+        'coarse': utils.load_jsonl('data/finkb/msmarco/coarse.jsonl')
+    },
+    'roberta': {
+        'granular': 'none',
+        'coarse': 'none'
+        # 'granular': utils.load_jsonl('data/finkb/roberta/finance_granular_coref_sample.jsonl'),
+        # 'coarse': utils.load_jsonl('data/finkb/roberta/finance_coarse_coref_sample.jsonl')
+    },
+}
+
+def search_query(e1, e2, granular=True, dir=False, threshold=0.5, top=100, model="finbert"):
+    e1_embedding = models[model].encode_entity(e1.strip())
+    e2_embedding = models[model].encode_entity(e2.strip())
+
+    # select finkb
+    granular_str = "granular" if granular else "coarse"
+    finkb_list = finkbs[model][granular_str]
+    
+    similar_abstracts_dict = { }
+    # iterate thru all finkb entities
+    for rel in finkb_list:
+        # query similarity
+        rel_score = models[model].query_similarity(e1_embedding, e2_embedding, rel["E1_CODE"], rel["E2_CODE"], dir)
+
+        doc_key = rel["DOC_KEY"]
+        # update similarity document
+        if rel_score > threshold:
+            if doc_key in similar_abstracts_dict:
+                similar_abstracts_dict[doc_key].add_relation(rel, rel_score)
+            else:
+                new_abstract = abstract.Abstract(doc_key)
+                new_abstract.add_relation(rel, rel_score)
+                similar_abstracts_dict[doc_key] = new_abstract
+    
+    # select top abstracts
+    similar_abstracts_list = sorted(similar_abstracts_dict.values(), reverse=True)[:top]
+
+    # retrieve jsons
+    similar_abstracts_dict = {
+        x.get_doc_key() : x.to_dict() for x in similar_abstracts_list
+    }
+
+    return similar_abstracts_dict

--- a/finsearch_backend_embedding/utils.py
+++ b/finsearch_backend_embedding/utils.py
@@ -1,0 +1,19 @@
+import json
+import ast
+import pandas as pd
+
+def load_json(filename):
+    with open(filename, 'r') as json_file:
+        data = json.load(json_file)
+    return data
+
+def load_jsonl(filename):
+    with open(filename, 'r') as jsonl_file:
+        data = list(jsonl_file)
+        data = [json.loads(x) for x in data]
+    return data
+
+def load_csv(filename, list_cols=[]):
+    converters = { x : ast.literal_eval for x in list_cols }
+    data = pd.read_csv(filename, converters=converters)
+    return data

--- a/finsearch_backend_query/app.py
+++ b/finsearch_backend_query/app.py
@@ -1,0 +1,42 @@
+from flask import Flask, request
+from flask_cors import CORS
+import requests
+
+# instantiate the app
+app = Flask(__name__)
+app.config.from_object(__name__)
+
+# enable CORS
+CORS(app, resources={r'/*': {'origins': '*'}})
+
+@app.route("/")
+def main():
+    return "<h1>Finsearch Backend Query</h1>"
+
+@app.route("/query", methods=["GET", "POST"])
+def query():
+    response_object = { "status": "success" }
+    # query
+    post_data = request.get_json()
+    entity1 = post_data.get('entity1')
+    entity2 = post_data.get('entity2')
+    direction = post_data.get('direction')
+    threshold = post_data.get('threshold')
+    granular = post_data.get('granular')
+    model = post_data.get('model')
+
+    query_str = 'http://127.0.0.1:5000/search?' + '&'.join([
+        f'entity1={entity1}',
+        f'entity2={entity2}',
+        f'direction={direction}',
+        f'threshold={threshold}',
+        f'granular={granular}',
+        f'model={model}',
+    ])
+    r = requests.get(query_str)
+    response_object['results'] = r.json()["0"]
+    response_object['granular'] = granular
+    return response_object
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5001)

--- a/finsearch_frontend/src/components/Search.vue
+++ b/finsearch_frontend/src/components/Search.vue
@@ -211,7 +211,7 @@ export default {
         submit(event) {
             this.display.loading = true
             event.preventDefault()
-            const path = 'http://137.132.83.244/testFlask1/search'
+            const path = 'http://137.132.83.244/finsearchBackend/query'
             const search_query = {
                 entity1: this.form.entity1,
                 entity2: this.form.entity2,

--- a/scripts/search/evaluate_encoder.py
+++ b/scripts/search/evaluate_encoder.py
@@ -16,13 +16,9 @@ models = {
     'fin_msmarco': encoder.Encoder('models/fin-msmarco')
 }
 # EVALUATION RESULTS:
-# {'stsb_multiqa': 0.44527515151537955, 'finbert': 0.13985654120643934, 'multiqa': 0.47037548606283963, 
-# 'msmarco': 0.43209875269172093, 'roberta': 0.3503788669841985}
-# {'stsb_multiqa': 0.44779870183517534, 'finbert': 0.16960061550140382, 'multiqa': 0.465436761106054, 
-# 'msmarco': 0.4332077649856607, 'roberta': 0.3410490820556879}
 # {'stsb_multiqa': 0.44779870183517534, 'finbert': 0.16960061550140382, 'multiqa': 0.465436761106054, 
 # 'msmarco': 0.4332077649856607, 'roberta': 0.3410490820556879, 'fin_multiqa': 0.48745486815770467, 
-# 'fin_msmarco': 0.44320187172542014}
+# 'fin_msmarco': 0.44320187172542014, 'fin_tapt':0.24985654120643934}
 
 def compute_similarity(e1, e2, model):
     e1_embedding = models[model].encode_entity(e1.strip())


### PR DESCRIPTION
Backend had to be split into 2 microservices:

1. finsearch_backend_query: API gateway - receives the API request and calls the embedder 
2. finsearch_backend_embedding: Embeds text based on encoded information